### PR TITLE
Add 'ignoreUndeclared' converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ These converters match their elements against a given converter.
 - `strict(<{ [key]: converter function }>)` - Given an object of keys to converters creates a converter that matches input keys with the declared converters and returns the resulting object. Only declared keys are returned.
 - `shape(<{ [key]: converter function }>)` - Same as strict but any keys present on the input that are not declared are also returned.
 - `partial(<strict or shape>)` - Given either a strict or shape converter makes every field optional, maintains strictness.
+- `ignoreUndeclared(<strict or shape>)` - Given either a strict or shape converter, will ignore any undefined fields not on the original object
 - `optional(<converter function>)` - Create a converter function that passes undefined input around the inner converter, useful for marking optional fields in objects.
 
 ### Paths

--- a/src/__tests__/objects.test.ts
+++ b/src/__tests__/objects.test.ts
@@ -118,3 +118,72 @@ describe('partial', () => {
     });
   });
 });
+
+describe('ignoreUndeclared', () => {
+  describe('removes any undefined fields not declared on the original object', () => {
+    it('undefined typing', () => {
+      const output = t.ignoreUndeclared(t.shape({ undefined: t.undefined }))({});
+      expect(output).toStrictEqual({});
+      expect(Object.keys(output)).not.toContain('undefined');
+    });
+
+    it('optional typing', () => {
+      const output = t.ignoreUndeclared(t.shape({ optional: t.optional(t.string) }))({});
+      expect(output).toStrictEqual({});
+      expect(Object.keys(output)).not.toContain('optional');
+    });
+  });
+
+  describe('keeps any undefined fields explicitly declared on the original object', () => {
+    it('undefined typing', () => {
+      const output = t.ignoreUndeclared(t.shape({ undefined: t.undefined }))({
+        undefined: undefined
+      });
+      expect(output).toStrictEqual({ undefined: undefined });
+      expect(Object.keys(output)).toContain('undefined');
+    });
+
+    it('optional typing', () => {
+      const output = t.ignoreUndeclared(t.shape({ optional: t.optional(t.string) }))({
+        optional: undefined
+      });
+      expect(output).toStrictEqual({ optional: undefined });
+      expect(Object.keys(output)).toContain('optional');
+    });
+  });
+
+  describe('keeps undeclared fields that resolved an input value', () => {
+    it('using default', () => {
+      const output = t.ignoreUndeclared(
+        t.shape({ defaulted: t.optional(t.string).default(() => 'defaulted') })
+      )({});
+      expect(output).toMatchObject({
+        defaulted: 'defaulted'
+      });
+    });
+
+    it('using pipe', () => {
+      const output = t.ignoreUndeclared(
+        t.shape({ defaulted: t.optional(t.string).pipe(() => 'piped') })
+      )({});
+      expect(output).toMatchObject({
+        defaulted: 'piped'
+      });
+    });
+
+    it('using forPath', () => {
+      const output = t.ignoreUndeclared(
+        t.shape({ forPath: t.forPath([t.ParentPath, 'originalPath']) })
+      )({ originalPath: 'originalPath' });
+      expect(output).toMatchObject({
+        forPath: 'originalPath'
+      });
+    });
+  });
+
+  it('still throws errors on bad conversion', () => {
+    expect(() =>
+      t.ignoreUndeclared(t.shape({ undefined: t.undefined }))({ undefined: 'string' })
+    ).toThrowError();
+  });
+});


### PR DESCRIPTION
Something we were running into when using converters on endpoint inputs was that a `partial` converter would set all of its optional fields as `undefined` if they weren't included. This is usually fine but when using the output as a patch-style update to spread over another object it would override everything on the original object, essentially turning our Dynamo update operations into put operations.

What this converter does is, given an object converter, will disregard any undefined fields on the output that were not explicitly declared on the input. For example, given an input `{ }` run through converter `{ name: t.optional(t.string) }` would traditionally yield `{ name: undefined }` but with this converter decorator would also yield `{ }`.

It will only consider fields for deletion if the output was undefined, so given an input `{ }` run through converter `{ name: t.optional(t.string).default(() => 'Bobby') }` would still yield `{ name: 'Bobby' }`.

We wrote a converter like this in the stack to cover the case, but figured it might be useful to promote to a core converter.