### PR TITLE
Implement coercers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ These convert the basic types with some coercion.
 - `null` - allows null
 - `undefined` - allows undefined
 - `literal(<value>)` - create a new converter that expects a value === to the given value.
+- `none` - allows null or undefined
 
 ### Containers
 These converters match their elements against a given converter.
@@ -59,6 +60,9 @@ These converters match their elements against a given converter.
 - `shape(<{ [key]: converter function }>)` - Same as strict but any keys present on the input that are not declared are also returned.
 - `partial(<strict or shape>)` - Given either a strict or shape converter makes every field optional, maintains strictness.
 - `optional(<converter function>)` - Create a converter function that passes undefined input around the inner converter, useful for marking optional fields in objects.
+- `noneable(<converter function>)` - Create a converter function that passes undefined or null input around the inner converter, useful for marking optional fields in objects.
+- `noneableAsNull(<converter function>)` - Create a converter function that coerces undefined or null input to null around the inner converter, useful for marking optional fields in objects.
+- `noneableAsNull(<converter function>)` - Create a converter function that coerces undefined or null input to undefined around the inner converter, useful for marking optional fields in objects.
 
 ### Paths
 - `forPath(<path array>, ?<converter function>)` - Navigates to the given path (either relative or from root),returning the value that is there. Optionally apply a converter function to the value before it is returned.
@@ -68,6 +72,11 @@ These converters match their elements against a given converter.
 - `oneOf(<option[]>)` - Given an array of option values returns the value if it === the input value.
 -  `taggedUnion(<tagField>, <{ [tag]: converter function }>)` - Pulls the value of the property specified by the tag field off of the input and uses it to find the correct converter function. Tagged unions should be used instead of the `.or` combination for complex objects as we can report on errors better.
 - `select(<converter function>)` - Given a converter function that takes a value and returns a converter function create a converter that runs the returned converter function. Useful for when runtime inspection of values beyond a tagged union is needed.
+
+### Coercers
+- `coerce(<converter function[]>, value)` - given an array of converters if one succeeds at converting the input return the given value.
+- `noneAsNull` - coerces `none` values to `null`
+- `noneAsUndefined` - coerces `none` values to `undefined`
 
 ### Other
 - `compose(<converter function[]>, <combiner>)` - given one or more converters apply them and pass all the results to a combiner function that determines the result of the converter.

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "jest": "^25.4.0",
     "pre-commit": "^1.2.2",
     "prettier": "^2.0.5",
-    "rollup": "^2.7.2",
-    "rollup-plugin-dts": "^1.4.7",
+    "rollup": "^2.51.0",
+    "rollup-plugin-dts": "^3.0.2",
     "typescript": "^4.2.2"
   },
   "pre-commit": [

--- a/src/__tests__/basic-types.test.ts
+++ b/src/__tests__/basic-types.test.ts
@@ -74,7 +74,7 @@ describe('primitive types', () => {
         });
       });
 
-      it('converts empty strings', () => {
+      it('converts none strings', () => {
         expect(t.string('')).toBe('');
       });
     });
@@ -116,7 +116,7 @@ describe('primitive types', () => {
     });
 
     describe('from object', () => {
-      it('fails on empty object', () => {
+      it('fails on none object', () => {
         expect(() => t.string({})).toThrowError();
       });
 
@@ -126,7 +126,7 @@ describe('primitive types', () => {
     });
 
     describe('from array', () => {
-      it('fails on empty array', () => {
+      it('fails on none array', () => {
         expect(() => t.string([])).toThrowError();
       });
 
@@ -153,5 +153,15 @@ describe('primitive types', () => {
         expect(() => t.string(() => 'hey')).toThrowError();
       });
     });
+  });
+
+  it('Empty passes null values', () => {
+    expect(t.none(null, [], {})).toBe(null);
+  });
+  it('Empty passes undefind values', () => {
+    expect(t.none(undefined, [], {})).toBe(undefined);
+  });
+  it('Empty throws on non-null / non-undefined values', () => {
+    expect(() => t.none(false, [], {})).toThrow();
   });
 });

--- a/src/__tests__/coercers.test.ts
+++ b/src/__tests__/coercers.test.ts
@@ -1,0 +1,43 @@
+import * as t from 'type-shift';
+
+describe('coerce', () => {
+  it('works with a single converter', () => {
+    const coercer = t.coerce([t.string], 3);
+    expect(coercer('test')).toBe(3);
+  });
+
+  it('works with three converters', () => {
+    const coercer = t.coerce([t.string, t.boolean, t.null], 3);
+    expect(coercer('test')).toBe(3);
+    expect(coercer(true)).toBe(3);
+    expect(coercer(null)).toBe(3);
+  });
+
+  it('works with complex converters', () => {
+    const coercer = t.coerce([t.string, t.boolean, t.none], 3);
+    expect(coercer('test')).toBe(3);
+    expect(coercer(true)).toBe(3);
+    expect(coercer(null)).toBe(3);
+    expect(coercer(undefined)).toBe(3);
+  });
+});
+
+describe('noneAsNull', () => {
+  it('coerces undefined to null ', () => {
+    expect(t.noneAsNull(undefined)).toBe(null);
+  });
+
+  it('passes null thru', () => {
+    expect(t.noneAsNull(null)).toBe(null);
+  });
+});
+
+describe('noneAsUndefined', () => {
+  it('passes undefined thru', () => {
+    expect(t.noneAsUndefined(undefined)).toBe(undefined);
+  });
+
+  it('coerces null to undefined', () => {
+    expect(t.noneAsUndefined(null)).toBe(undefined);
+  });
+});

--- a/src/__tests__/decorators.test.ts
+++ b/src/__tests__/decorators.test.ts
@@ -1,15 +1,49 @@
-import { optional } from 'type-shift';
+import * as t from 'type-shift';
 
-describe('optional converters', () => {
-  it('allows undefined', () => {
-    const c = optional(() => 1);
-    expect(c(undefined, [], {})).toBe(undefined);
+const itConverts = (converterFactory: any, input: any, output: any) => {
+  it(`converts ${JSON.stringify(input)} to ${JSON.stringify(output)}`, () => {
+    const c = converterFactory(() => 1);
+    expect(c(input, [], {})).toBe(output);
   });
-  it('on not undefined passes through value', () => {
+};
+
+const itFailsConverting = (converterFactory: any, input: any) => {
+  it(`fails converting ${JSON.stringify(input)}`, () => {
+    const c = converterFactory(t.number);
+    expect(() => c(input, [], {})).toThrow();
+  });
+};
+
+const itPassesValueToInnerConverter = (converterFactory: any) => {
+  it('passes defined values to inner converter', () => {
     const inner = jest.fn(() => 1);
     const path = ['foo'];
     const entity = {};
-    expect(optional(inner)(3, path, entity)).toBe(1);
+    expect(converterFactory(inner)(3, path, entity)).toBe(1);
     expect(inner).toHaveBeenCalledWith(3, path, entity);
   });
+};
+
+describe('optional', () => {
+  itConverts(t.optional, undefined, undefined);
+  itFailsConverting(t.optional, null);
+  itPassesValueToInnerConverter(t.optional);
+});
+
+describe('noneable', () => {
+  itConverts(t.noneable, undefined, undefined);
+  itConverts(t.noneable, null, null);
+  itPassesValueToInnerConverter(t.noneable);
+});
+
+describe('noneableAsNull', () => {
+  itConverts(t.noneableAsNull, undefined, null);
+  itConverts(t.noneableAsNull, null, null);
+  itPassesValueToInnerConverter(t.noneableAsNull);
+});
+
+describe('noneableAsUndefined', () => {
+  itConverts(t.noneableAsUndefined, undefined, undefined);
+  itConverts(t.noneableAsUndefined, null, undefined);
+  itPassesValueToInnerConverter(t.noneableAsUndefined);
 });

--- a/src/basic-types.ts
+++ b/src/basic-types.ts
@@ -96,11 +96,34 @@ const NullConverter = literal<null>(null);
  */
 const UndefinedConverter = literal<undefined>(undefined);
 
+/**
+ * A type representing undefined or null
+ */
+export type None = null | undefined;
+
+/**
+ * Converter that matches the literal undefined or null,
+ * You can make values optionally none by using
+ * t.none.or(...)
+ */
+const NoneConverter = createConverter((value: unknown, path) => {
+  if (value === null) {
+    return null;
+  }
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  throw new ConverterError(value, 'none', path);
+}, 'none');
+
 export {
   NumberConverter as number,
   StringConverter as string,
   BooleanConverter as boolean,
   UnknownConverter as unknown,
+  NoneConverter as none,
   NeverConverter as never,
   NullConverter as null,
   UndefinedConverter as undefined

--- a/src/coercers.ts
+++ b/src/coercers.ts
@@ -1,0 +1,29 @@
+import { displayValue } from './formatting';
+import { Converter } from './core';
+import { None, none } from './basic-types';
+
+/**
+ * Given a set of converters if one succeeds at converting the input return the
+ * given value.
+ *
+ * @param converters - Array of converters to pass in.
+ * @param value - Value to return
+ *
+ */
+export const coerce = <V>(
+  converters: [Converter<any>, ...Converter<any>[]],
+  value: V
+): Converter<V> => {
+  const predicate = converters.reduce((c1, c2) => c1.or(c2));
+  return predicate.pipe(() => value, `${predicate.displayName} -> ${displayValue(value)}`);
+};
+
+/**
+ * A coercer that coerces values of None type to a null literal
+ */
+export const noneAsNull: Converter<None> = coerce([none], null);
+
+/**
+ * A coercer that coerces values of None type to an undefined literal
+ */
+export const noneAsUndefined: Converter<None> = coerce([none], undefined);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,3 +1,4 @@
+import { None } from './basic-types';
 import { Converter, ConverterFunction, createConverter, getConverterName } from './core';
 
 /**
@@ -10,6 +11,59 @@ export function optional<Result, Input = unknown>(
 ): Converter<Result | undefined, Input | undefined> {
   return createConverter((input, path, entity) => {
     if (input === undefined) {
+      return undefined;
+    }
+    return converter(input, path, entity);
+  }, `optional ${getConverterName(converter)}`);
+}
+
+/**
+ * Given a converter function make an noneable converter that allows `none`
+ * types to pass through
+ * @param converter - the inner converter function
+ */
+export function noneable<Result, Input = unknown>(
+  converter: ConverterFunction<Result, Input>
+): Converter<Result | None, Input | None> {
+  return createConverter((input, path, entity) => {
+    if (input === undefined) {
+      return undefined;
+    }
+
+    if (input === null) {
+      return null;
+    }
+
+    return converter(input, path, entity);
+  }, `optional ${getConverterName(converter)}`);
+}
+
+/**
+ * Given a converter function make an noneable converter function that also coerces
+ * `none` to `null`
+ * @param converter - the inner converter function
+ */
+export function noneableAsNull<Result, Input = unknown>(
+  converter: ConverterFunction<Result, Input>
+): Converter<Result | null, Input | None> {
+  return createConverter((input, path, entity) => {
+    if (input === undefined || input === null) {
+      return null;
+    }
+    return converter(input, path, entity);
+  }, `optional ${getConverterName(converter)}`);
+}
+
+/**
+ * Given a converter function make an noneable converter function that also coerces
+ * `none` to `undefined`
+ * @param converter - the inner converter function
+ */
+export function noneableAsUndefined<Result, Input = unknown>(
+  converter: ConverterFunction<Result, Input>
+): Converter<Result | undefined, Input | None> {
+  return createConverter((input, path, entity) => {
+    if (input === undefined || input === null) {
       return undefined;
     }
     return converter(input, path, entity);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './basic-types';
 export * from './container';
+export * from './coercers';
 export * from './composers';
 export * from './core';
 export * from './decorators';

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+  dependencies:
+    "@babel/highlight" "^7.12.13"
+
 "@babel/compat-data@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.6.tgz#3f604c40e420131affe6f2c8052e9a275ae2049b"
@@ -231,6 +238,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
+"@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
+
 "@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
@@ -261,6 +273,15 @@
   integrity sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.12.13":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.0.tgz#3197e375711ef6bf834e67d0daec88e4f46113cf"
+  integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -2616,10 +2637,15 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.1.2, fsevents@~2.1.2:
+fsevents@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -3806,6 +3832,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -4657,19 +4690,21 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-dts@^1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-1.4.7.tgz#6255147ac777314c0725a1efcb42df10fe282243"
-  integrity sha512-QkunbJ96yUNkW95k/Vd6SdTjCbWSG0rMVUtpHSCwfg078Z7vbDaBnfz/gkSqR5h8WFMxoccBT4aodHm6387Jvg==
+rollup-plugin-dts@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-3.0.2.tgz#2b628d88f864d271d6eaec2e4c2a60ae4e944c5c"
+  integrity sha512-hswlsdWu/x7k5pXzaLP6OvKRKcx8Bzprksz9i9mUe72zvt8LvqAb/AZpzs6FkLgmyRaN8B6rUQOVtzA3yEt9Yw==
+  dependencies:
+    magic-string "^0.25.7"
   optionalDependencies:
-    "@babel/code-frame" "^7.8.3"
+    "@babel/code-frame" "^7.12.13"
 
-rollup@^2.7.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.8.0.tgz#a1d63fa8331f5c362f025a7fee78b86d4ada5cef"
-  integrity sha512-hyjpreMA0BTNrO68o4wCtcktwYTK8o1UtauOqsPniwDGzN2PvNaKmwa/RHmjNHJMrt6ItY2C7XjpT7TDf6WmJw==
+rollup@^2.51.0:
+  version "2.51.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.51.0.tgz#ffd847882283998fc8611cd57af917f173b4ab5c"
+  integrity sha512-ITLt9sScNCBVspSHauw/W49lEZ0vjN8LyCzSNsNaqT67vTss2lYEfOyxltX8hjrhr1l/rQwmZ2wazzEqhZ/fUg==
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -4885,6 +4920,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spawn-sync@^1.0.15:
   version "1.0.15"


### PR DESCRIPTION
## TL;DR

The point of this PR is to create syntactic sugar for handling Typescript's null strictness in a safe way to prevent pedantic mistakes for mixing up `null` and `undefined` when it doesn't truly matter.


## Empty type

We create a new type called `Empty` exposed as a `t.empty` converter which allows you to pass `undefined` or `null` values.

## Coercers

Building on this we create a concept called a `coercer` which is exposed as `t.coerce` this allows you to input a set of converters and a value, if any converter successfully passes it returns the given value.

We bake in 2 default coercers called `emptyAsNull` and `emptyAsUndefined`. These coercers allow `empty` values but return `null` and `undefined` respectfully.

## CONTROVERSIAL SECTION -- optional

The idea here is to then pass on the `empty` concept into `t.optional`.

This PR modifies `t.optional` to coerce `null` into `undefined` and creates a `t.strictOptional` which retains the original behavior.

This is arguably the most semantic way to handle this and preserves the original intent that this library is an `undefined` based library following the MS standard but can seamlessly interoperate with libraries / datasets that follow a null standard or a mixed standard.

This is probably the most controversial change here, there are obviously other solutions to organizing this. Let me know what you guys think.