### PR TITLE
Input Patching

### DIFF
--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -1,0 +1,146 @@
+import * as t from 'type-shift';
+
+describe('patch', () => {
+  describe('given a narrowed field', () => {
+    const converter = t.strict({
+      count: t.oneOf([-1, 0, 1])
+    });
+    const patched = t.patch(
+      ['count'],
+      t.number.pipe((v) => (v < 0 ? -1 : v > 0 ? 1 : 0))
+    )(converter);
+
+    it('allows narrowing of field', () => {
+      const result = patched({ count: -2 });
+      expect(result).toEqual({ count: -1 });
+    });
+    it('skips conversion if type is wrong', () => {
+      expect(() => patched({ count: 'test' })).toThrow(
+        'At Path $.count, expected -1 | 0 | 1 but was "test"'
+      );
+    });
+  });
+
+  describe('given a legacy field', () => {
+    const converter = t.strict({
+      items: t.strict({
+        data: t.array(t.strict({ name: t.string })),
+        count: t.number
+      })
+    });
+    const patchedItems = t.patch(
+      ['items'],
+      t.undefined.pipe(t.forPath([t.ParentPath, 'count'])).pipe((count) => ({ data: [], count }))
+    )(converter);
+
+    const pathcedCount = t.patch(
+      ['items', 'count'],
+      t.undefined.pipe(t.forPath([t.ParentPath, t.ParentPath, 'count']))
+    )(converter);
+
+    const chainedPatch = t.patches(
+      t.patch(['items', 'data'], t.undefined.pipe(t.forPath([t.ParentPath], t.array(t.unknown)))),
+      t.patch(
+        ['items', 'count'],
+        t.undefined
+          .pipe(t.forPath([t.ParentPath, 'data'], t.array(t.unknown)))
+          .pipe((d) => d.length)
+      )
+    )(converter);
+
+    it('uses value from legacy field', () => {
+      const result = patchedItems({ count: 0 });
+      expect(result).toEqual({ items: { count: 0, data: [] } });
+    });
+
+    it('deeply sets value', () => {
+      const result = pathcedCount({ items: { data: [] }, count: 0 });
+      expect(result).toEqual({ items: { data: [], count: 0 } });
+    });
+
+    it('chains multiple transforms', () => {
+      const result = chainedPatch({ items: [{ name: 'test' }] });
+      expect(result).toEqual({
+        items: {
+          data: [{ name: 'test' }],
+          count: 1
+        }
+      });
+    });
+  });
+
+  describe('given collection types, patches all elements', () => {
+    const converter = t.strict({
+      sorted: t.array(
+        t.strict({
+          id: t.string
+        })
+      ),
+      lookup: t.record(
+        t.strict({
+          name: t.string
+        })
+      )
+    });
+
+    const stringToIdObject = t.patch(
+      ['sorted', t.AllElements, 'id'],
+      t.forPath([t.ParentPath], t.string)
+    )(converter);
+
+    it('converts all elements in array', () => {
+      const result = stringToIdObject({ sorted: ['1', '2', '3', '4'], lookup: {} });
+      expect(result).toEqual({
+        sorted: [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }],
+        lookup: {}
+      });
+    });
+
+    it('creates empty array if not present', () => {
+      const result = stringToIdObject({ sorted: null, lookup: {} });
+      expect(result).toEqual({
+        sorted: [],
+        lookup: {}
+      });
+    });
+
+    const firstLastToName = t.patch(
+      ['lookup', t.AllEntries, 'name'],
+      t.compose(
+        [
+          t.forPath([t.ParentPath, 'firstName'], t.string),
+          t.forPath([t.ParentPath, 'lastName'], t.string)
+        ],
+        (first: string, last: string) => `${first} ${last}`
+      )
+    )(converter);
+
+    it('converts all elements in the record', () => {
+      const result = firstLastToName({
+        sorted: [],
+        lookup: {
+          a: { firstName: 'Test', lastName: 'McTester' },
+          b: { firstName: 'Failing', lastName: 'Tester' }
+        }
+      });
+      expect(result).toEqual({
+        sorted: [],
+        lookup: {
+          a: { name: 'Test McTester' },
+          b: { name: 'Failing Tester' }
+        }
+      });
+    });
+
+    it('creates empty record if not present', () => {
+      const result = firstLastToName({
+        sorted: [],
+        lookup: null
+      });
+      expect(result).toEqual({
+        sorted: [],
+        lookup: {}
+      });
+    });
+  });
+});

--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -119,6 +119,20 @@ describe('forPath', () => {
       expect(testConverter(testItem).childA.childB.cloneAll).toMatchObject({ childA: 'hey' });
     });
 
+    it('resolves immediate parent', () => {
+      const testConverter = t.strict({
+        child: t.strict({
+          subChild: t.forPath([t.ParentPath], t.shape({ sibling: t.string }))
+        })
+      });
+      const testItem = { child: { sibling: 'test' }};
+      expect(testConverter(testItem)).toMatchObject({
+        child: {
+          subChild: { sibling: 'test' }
+        }
+      });
+    })
+
     it("still resolves '.'", () => {
       const testConverter = t.shape({
         '.': t.string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,6 @@ export * from './errors';
 export * from './formatting';
 export * from './func';
 export * from './objects';
+export * from './patch';
 export * from './paths';
 export * from './unions';

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -1,0 +1,118 @@
+import { Converter, ConverterFunction, createConverter, getConverterName } from './core';
+
+/** When used in a patch path signals that the patch applies to all elements of an array */
+export const AllElements = Symbol('[*]');
+/** When used in patch path signals that the patch applies to all entries in an object */
+export const AllEntries = Symbol('.*');
+
+export type PatchTarget = (string | number | typeof AllElements | typeof AllEntries)[];
+
+/**
+ * An input Patch.
+ *
+ * Patches wrap a converter and modify the input (and entity) before invoking the converter
+ * they provide a clean way to declare and compose input transformations for things
+ * like legacy field mapping or type narrowing.
+ */
+export type Patch = <TResult>(converter: ConverterFunction<TResult>) => Converter<TResult>;
+
+const apply = (
+  target: unknown,
+  targetPath: PatchTarget,
+  currentPath: (number | string)[],
+  update: (v: unknown, path: (number | string)[]) => unknown
+): unknown => {
+  try {
+    if (targetPath.length === 0) {
+      return update(target, currentPath);
+    } else {
+      const [part, ...path] = targetPath;
+      if (part === AllElements) {
+        const into = target == null || !Array.isArray(target) ? [] : target;
+        // apply the patch to every element
+        return into.reduce(
+          (t: unknown, _, index) => apply(t, [index, ...path], currentPath, update),
+          into
+        );
+      } else if (part === AllEntries) {
+        const into = typeof target !== 'object' || target == null ? {} : target;
+        // apply the patch to every key
+        return Object.keys(into).reduce(
+          (t: unknown, key: string) => apply(t, [key, ...path], currentPath, update),
+          into
+        );
+      } else if (typeof part === 'string') {
+        // because the current path part is a string we're going to be
+        // setting the property on an object.
+        const into = target == null || typeof target !== 'object' || target === null ? {} : target;
+        const n = (into as Record<string, unknown>)[part];
+        const r = apply(n, path, [...currentPath, part], update);
+        // optimize copying a whole object if not necessary
+        if (n === r) {
+          return into;
+        } else {
+          return {
+            ...into,
+            [part]: r
+          };
+        }
+      } else {
+        // because the current path part is a number we're going to be
+        // setting the element of an array
+        const into = target == null || !Array.isArray(target) ? [] : target;
+        const n = into[part];
+        const r = apply(n, path, [...currentPath, part], update);
+        // optimize copying a whole array if not necessary
+        if (n === r) {
+          return into;
+        } else {
+          return [...into.slice(0, part), r, ...into.slice(part + 1)];
+        }
+      }
+    }
+  } catch (_ignore) {
+    // errors applying a patch are ignored
+    // and the input is returned as-is
+    return target;
+  }
+};
+
+/**
+ * Creates a new Patch
+ *
+ * The patcher converter will be invoked with the input value from the target path, if that converter
+ * does not throw an error the result of the converter will be "patched" into the input at the target path.
+ * @param targetPath the target property to patch
+ * @param patcher a converter function that transforms the value in the input to the patched value.
+ * @returns a Patch that can wrap a converter.
+ */
+export const patch = (
+  targetPath: PatchTarget,
+  patcher: ConverterFunction<unknown, unknown>
+): Patch => {
+  return <TResult>(converter: ConverterFunction<TResult>) => {
+    return createConverter((input, path, entity) => {
+      const bindEntity = (v: unknown, p: (number | string)[]) => patcher(v, p, entity);
+      const nextInput = apply(input, targetPath, path, bindEntity);
+      // if the entity and the input are not the same then we want to also update the entity.
+      // this allows subsequent converters or patches to use things like t.forPath to see the new fields we're creating
+      // this is useful when we're apply a series of patches that can be thought of as version upgrades (v1 -> v2 -> v3)
+      // after each patch is applied we want to
+      const nextEntity =
+        input === entity ? nextInput : apply(entity, [...path, ...targetPath], [], bindEntity);
+      return converter(nextInput, path, nextEntity);
+    }, getConverterName(converter));
+  };
+};
+
+/**
+ * Given a series of patches create a patch that applies them in sequence.
+ *
+ * This is equivalent to: patch1(patch2(patch3(converter))) but allow this to be written
+ * as: patches(patch1, patch2, patch3)(converter) additionally the patches can more easily be applied to multiple converters.
+ * @param patches the patches to apply in sequence.
+ * @returns a Patch
+ */
+export const patches = (...patches: Patch[]): Patch => {
+  return (converter) => patches.reduceRight((c, p) => p(c), createConverter(converter));
+};

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -33,8 +33,8 @@ const followPath = (
         const count = targetPath.findIndex((part) => part !== ParentPath, 0);
 
         if (count === -1) {
-          // If we go all the way to the root...
-          targetPath = [];
+          // every item in targetPath is a ParentPath node
+          targetPath = currentPath.slice(0, currentPath.length - targetPath.length);
         } else {
           // Otherwise return currentPath and targetPath merged.
           targetPath = [


### PR DESCRIPTION
type-shift has traditionally been setup so the converter for a given field can infer a value for it's field from a legacy field (see forPath converter)
While this works in practice it can make for hard to read converters and for odd interactions like the `.default` and `optional` interaction discussed in #19.

Instead of encoding history in the form of converters this moves towards the idea of patches. A patch targets a specific field and provides a way to set a value on that field.
We leverage the existing converter functions as a way of setting values. If a converter is successful then the value is set, if it fails then the value is left as-is. This
allows things like field narrowing / renaming using something like `t.literal('legacyName').pipe(() => 'newName')` Additionally inferring values for new fields from legacy fields
can be done using `t.undefined.pipe(t.forPath([...]))`.
See tests for examples of doing this.

Additionally patching as a concept is more composable than using the `.default` and other options. To aid in this I've included a `patches` function that composes multiple patches
sequentially. Patches modify both the value and the root entity when their applied. this is useful since it allows each patch to build off of the previous patched value,
for instance the first patch in a chain my introduce a new field that wasn't there before, the second patch in the chain may use that new field to infer the value of another field, etc.
This differs from the use of `.default` which has traditionally required lots of awkward repeated code to allow inferring from already inferred values.