### PR TITLE
Fix Path bug with ParentPath

### DIFF
--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -119,6 +119,20 @@ describe('forPath', () => {
       expect(testConverter(testItem).childA.childB.cloneAll).toMatchObject({ childA: 'hey' });
     });
 
+    it('resolves immediate parent', () => {
+      const testConverter = t.strict({
+        child: t.strict({
+          subChild: t.forPath([t.ParentPath], t.shape({ sibling: t.string }))
+        })
+      });
+      const testItem = { child: { sibling: 'test' }};
+      expect(testConverter(testItem)).toMatchObject({
+        child: {
+          subChild: { sibling: 'test' }
+        }
+      });
+    })
+
     it("still resolves '.'", () => {
       const testConverter = t.shape({
         '.': t.string,

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -33,8 +33,8 @@ const followPath = (
         const count = targetPath.findIndex((part) => part !== ParentPath, 0);
 
         if (count === -1) {
-          // If we go all the way to the root...
-          targetPath = [];
+          // every item in targetPath is a ParentPath node
+          targetPath = currentPath.slice(0, currentPath.length - targetPath.length);
         } else {
           // Otherwise return currentPath and targetPath merged.
           targetPath = [


### PR DESCRIPTION
Previously if forPath was given an array of solely parent paths it would
reset to the root path, this is very wrong. Instead we should go up
from the current path based on the number of parent path elements.