### PR TITLE
PROPOSAL: Update the order in which "optional" decorators are evaluated

### DIFF
--- a/src/__tests__/core.test.ts
+++ b/src/__tests__/core.test.ts
@@ -86,11 +86,11 @@ describe('createConverter', () => {
     more.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
     const converter = t
       .createConverter(() => {
-      throw less;
+        throw less;
       })
       .or(() => {
-      throw more;
-    });
+        throw more;
+      });
     expect(() => converter(0)).toThrow(more);
   });
   it('or thows error with deeper errors', () => {
@@ -98,11 +98,11 @@ describe('createConverter', () => {
     const deep = new t.ConverterError('test', 'not-test', ['field', 0, 'other']);
     const converter = t
       .createConverter(() => {
-      throw shallow;
+        throw shallow;
       })
       .or(() => {
-      throw deep;
-    });
+        throw deep;
+      });
     expect(() => converter(0)).toThrow(deep);
   });
   it('or prefers deeper errors over more errors', () => {
@@ -111,11 +111,11 @@ describe('createConverter', () => {
     const lessDeep = new t.ConverterError('test', 'not-test', ['field', 0, 'other']);
     const converter = t
       .createConverter(() => {
-      throw moreShallow;
+        throw moreShallow;
       })
       .or(() => {
-      throw lessDeep;
-    });
+        throw lessDeep;
+      });
     expect(() => converter(0)).toThrow(lessDeep);
   });
   it('or uses count of errors at max depth', () => {
@@ -127,11 +127,11 @@ describe('createConverter', () => {
     oneDeepest.errorFields['$.field[0]'] = { expected: 'test', actual: 'not-test' };
     const converter = t
       .createConverter(() => {
-      throw twoDeepest;
+        throw twoDeepest;
       })
       .or(() => {
-      throw oneDeepest;
-    });
+        throw oneDeepest;
+      });
     expect(() => converter(0)).toThrow(twoDeepest);
   });
   it('or throws new errors if the errors tie depth and count', () => {
@@ -143,11 +143,11 @@ describe('createConverter', () => {
     errorTwo.errorFields['$.other[1]'] = { expected: 'test', actual: 'not-test' };
     const converter = t
       .createConverter(() => {
-      throw errorOne;
+        throw errorOne;
       })
       .or(() => {
-      throw errorTwo;
-    });
+        throw errorTwo;
+      });
     expect.assertions(2);
     try {
       converter(0);
@@ -170,8 +170,8 @@ describe('createConverter', () => {
     const converter = t
       .createConverter((v) => v)
       .default(() => {
-      throw new Error();
-    });
+        throw new Error();
+      });
     expect(() => converter(undefined)).toThrow();
   });
   it("default doesn't invoke default converter if defined", () => {
@@ -200,5 +200,12 @@ describe('createConverter', () => {
       // no-op
     }
     expect(d).not.toHaveBeenCalled();
+  });
+  it("default doesn't return undefined when original converters succeed", () => {
+    const converter = t.shape({
+      one: t.string,
+      two: t.forPath([t.ParentPath, 'one'], t.string).default(() => 5)
+    });
+    expect(converter({ one: 'hello', two: undefined })).toEqual({ one: 'hello', two: 'hello' });
   });
 });

--- a/src/__tests__/core.test.ts
+++ b/src/__tests__/core.test.ts
@@ -1,11 +1,11 @@
-import { createConverter, ConverterError } from 'type-shift';
+import * as t from 'type-shift';
 
 describe('createConverter', () => {
   it('creates converter with name of function', () => {
     function one() {
       return 1;
     }
-    const converter = createConverter(one);
+    const converter = t.createConverter(one);
     expect(converter).toHaveProperty('displayName', 'one');
   });
   it('creates converter with displayName', () => {
@@ -13,26 +13,26 @@ describe('createConverter', () => {
       return 1;
     }
     (one as any).displayName = 'two';
-    const converter = createConverter(one);
+    const converter = t.createConverter(one);
     expect(converter).toHaveProperty('displayName', 'two');
   });
   it('creates converter with name', () => {
     function one() {
       return 1;
     }
-    const converter = createConverter(one, 'three');
+    const converter = t.createConverter(one, 'three');
     expect(converter).toHaveProperty('displayName', 'three');
   });
   it('creates a converter that passes through default path and entity', () => {
     const inner = jest.fn(() => 1);
-    const converter = createConverter(inner);
+    const converter = t.createConverter(inner);
     converter(1);
     expect(inner).toHaveBeenCalledWith(1, [], 1);
   });
   it('pipes data into the next function', () => {
     const one = jest.fn(() => 1);
     const two = jest.fn(() => 2);
-    const converter = createConverter(one).pipe(two);
+    const converter = t.createConverter(one).pipe(two);
     expect(converter(0)).toBe(2);
     expect(one).toHaveBeenCalledWith(0, [], 0);
     expect(two).toHaveBeenCalledWith(1, [], 0);
@@ -40,17 +40,17 @@ describe('createConverter', () => {
   it('chains name of piped function', () => {
     const one = () => 1;
     const two = () => 2;
-    const converter = createConverter(one).pipe(two);
+    const converter = t.createConverter(one).pipe(two);
     expect(converter.displayName).toBe('one -> two');
   });
   it('uses anonymous name if pipe is anonymous', () => {
-    const converter = createConverter(() => 1, 'three').pipe(() => 2);
+    const converter = t.createConverter(() => 1, 'three').pipe(() => 2);
     expect(converter.displayName).toBe('three -> anonymous');
   });
   it('uses given name for piped function', () => {
     const one = () => 1;
     const two = () => 2;
-    const converter = createConverter(one).pipe(two, 'three');
+    const converter = t.createConverter(one).pipe(two, 'three');
     expect(converter.displayName).toBe('three');
   });
   it('ors two or more converters', () => {
@@ -58,7 +58,7 @@ describe('createConverter', () => {
       throw new Error();
     });
     const two = jest.fn(() => 2);
-    const converter = createConverter(one).or(two);
+    const converter = t.createConverter(one).or(two);
     expect(converter(0)).toBe(2);
     expect(one).toHaveBeenCalledWith(0, [], 0);
     expect(two).toHaveBeenCalledWith(0, [], 0);
@@ -66,7 +66,7 @@ describe('createConverter', () => {
   it('or returns first successful result', () => {
     const one = jest.fn(() => 1);
     const two = jest.fn(() => 2);
-    const converter = createConverter(one).or(two);
+    const converter = t.createConverter(one).or(two);
     expect(converter(0)).toBe(1);
     expect(two).not.toHaveBeenCalled();
   });
@@ -77,65 +77,75 @@ describe('createConverter', () => {
     const two = jest.fn(() => {
       throw new Error();
     });
-    const converter = createConverter(one).or(two);
+    const converter = t.createConverter(one).or(two);
     expect(() => converter(0)).toThrow();
   });
   it('or throws error with more errors', () => {
-    const less = new ConverterError('test', 'not-test', ['field', 0]);
-    const more = new ConverterError('test', 'not-test', ['field', 0]);
+    const less = new t.ConverterError('test', 'not-test', ['field', 0]);
+    const more = new t.ConverterError('test', 'not-test', ['field', 0]);
     more.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
-    const converter = createConverter(() => {
+    const converter = t
+      .createConverter(() => {
       throw less;
-    }).or(() => {
+      })
+      .or(() => {
       throw more;
     });
     expect(() => converter(0)).toThrow(more);
   });
   it('or thows error with deeper errors', () => {
-    const shallow = new ConverterError('test', 'not-test', ['field', 0]);
-    const deep = new ConverterError('test', 'not-test', ['field', 0, 'other']);
-    const converter = createConverter(() => {
+    const shallow = new t.ConverterError('test', 'not-test', ['field', 0]);
+    const deep = new t.ConverterError('test', 'not-test', ['field', 0, 'other']);
+    const converter = t
+      .createConverter(() => {
       throw shallow;
-    }).or(() => {
+      })
+      .or(() => {
       throw deep;
     });
     expect(() => converter(0)).toThrow(deep);
   });
   it('or prefers deeper errors over more errors', () => {
-    const moreShallow = new ConverterError('test', 'not-test', ['field', 0]);
+    const moreShallow = new t.ConverterError('test', 'not-test', ['field', 0]);
     moreShallow.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
-    const lessDeep = new ConverterError('test', 'not-test', ['field', 0, 'other']);
-    const converter = createConverter(() => {
+    const lessDeep = new t.ConverterError('test', 'not-test', ['field', 0, 'other']);
+    const converter = t
+      .createConverter(() => {
       throw moreShallow;
-    }).or(() => {
+      })
+      .or(() => {
       throw lessDeep;
     });
     expect(() => converter(0)).toThrow(lessDeep);
   });
   it('or uses count of errors at max depth', () => {
-    const twoDeepest = new ConverterError('test', 'not-test', ['field']);
+    const twoDeepest = new t.ConverterError('test', 'not-test', ['field']);
     twoDeepest.errorFields['$.field[0]'] = { expected: 'test', actual: 'not-test' };
     twoDeepest.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
-    const oneDeepest = new ConverterError('test', 'not-test', ['field']);
+    const oneDeepest = new t.ConverterError('test', 'not-test', ['field']);
     oneDeepest.errorFields['$.other'] = { expected: 'test', actual: 'not-test' };
     oneDeepest.errorFields['$.field[0]'] = { expected: 'test', actual: 'not-test' };
-    const converter = createConverter(() => {
+    const converter = t
+      .createConverter(() => {
       throw twoDeepest;
-    }).or(() => {
+      })
+      .or(() => {
       throw oneDeepest;
     });
     expect(() => converter(0)).toThrow(twoDeepest);
   });
   it('or throws new errors if the errors tie depth and count', () => {
-    const errorOne = new ConverterError('test', 'not-test', ['field']);
+    const errorOne = new t.ConverterError('test', 'not-test', ['field']);
     errorOne.errorFields['$.field[0]'] = { expected: 'test', actual: 'not-test' };
     errorOne.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
-    const errorTwo = new ConverterError('test', 'not-test', ['other']);
+    const errorTwo = new t.ConverterError('test', 'not-test', ['other']);
     errorTwo.errorFields['$.other[0]'] = { expected: 'test', actual: 'not-test' };
     errorTwo.errorFields['$.other[1]'] = { expected: 'test', actual: 'not-test' };
-    const converter = createConverter(() => {
+    const converter = t
+      .createConverter(() => {
       throw errorOne;
-    }).or(() => {
+      })
+      .or(() => {
       throw errorTwo;
     });
     expect.assertions(2);
@@ -147,37 +157,39 @@ describe('createConverter', () => {
     }
   });
   it(`default falls back on undefined`, () => {
-    const one = createConverter((v) => v);
+    const one = t.createConverter((v) => v);
     const converter = one.default(() => 'value');
     expect(converter(undefined)).toBe('value');
   });
   it('default passes default value through converter', () => {
-    const one = createConverter<string, number | string>((v) => v.toString());
+    const one = t.createConverter<string, number | string>((v) => v.toString());
     const converter = one.default(() => 5);
     expect(converter(undefined)).toBe('5');
   });
   it('default throws if the default value converter throws', () => {
-    const converter = createConverter((v) => v).default(() => {
+    const converter = t
+      .createConverter((v) => v)
+      .default(() => {
       throw new Error();
     });
     expect(() => converter(undefined)).toThrow();
   });
   it("default doesn't invoke default converter if defined", () => {
-    const one = createConverter((v) => v);
+    const one = t.createConverter((v) => v);
     const d = jest.fn(() => 5);
     const converter = one.default(d);
     converter(3);
     expect(d).not.toHaveBeenCalled();
   });
   it('default throws if converter function throws', () => {
-    const one = createConverter(() => {
+    const one = t.createConverter(() => {
       throw new Error();
     });
     const converter = one.default(() => 5);
     expect(() => converter(undefined)).toThrow();
   });
   it("default doesn't invoke default converter if converter throws on a defined value", () => {
-    const one = createConverter(() => {
+    const one = t.createConverter(() => {
       throw new Error();
     });
     const d = jest.fn(() => 5);

--- a/src/__tests__/decorators.test.ts
+++ b/src/__tests__/decorators.test.ts
@@ -1,15 +1,19 @@
 import * as t from 'type-shift';
 
+const failingConverter = t.createConverter((input, path) => {
+  throw new t.ConverterError(input, 'Error', path);
+});
+
 const itConverts = (converterFactory: any, input: any, output: any) => {
   it(`converts ${JSON.stringify(input)} to ${JSON.stringify(output)}`, () => {
-    const c = converterFactory(() => 1);
+    const c = converterFactory(failingConverter);
     expect(c(input, [], {})).toBe(output);
   });
 };
 
 const itFailsConverting = (converterFactory: any, input: any) => {
   it(`fails converting ${JSON.stringify(input)}`, () => {
-    const c = converterFactory(t.number);
+    const c = converterFactory(failingConverter);
     expect(() => c(input, [], {})).toThrow();
   });
 };
@@ -24,26 +28,40 @@ const itPassesValueToInnerConverter = (converterFactory: any) => {
   });
 };
 
+const itAttemptsWrappedConvertersBeforeReturning = (converterFactory: any) => {
+  it('attempts wrapped converters before returning', () => {
+    const c = t.shape({
+      a: converterFactory(t.string.or(t.forPath([t.ParentPath, 'b'], t.string))),
+      b: t.unknown
+    });
+    expect(c({ a: undefined, b: 'hello' })).toEqual({ a: 'hello', b: 'hello' });
+  });
+};
+
 describe('optional', () => {
   itConverts(t.optional, undefined, undefined);
   itFailsConverting(t.optional, null);
   itPassesValueToInnerConverter(t.optional);
+  itAttemptsWrappedConvertersBeforeReturning(t.optional);
 });
 
 describe('noneable', () => {
   itConverts(t.noneable, undefined, undefined);
   itConverts(t.noneable, null, null);
   itPassesValueToInnerConverter(t.noneable);
+  itAttemptsWrappedConvertersBeforeReturning(t.noneable);
 });
 
 describe('noneableAsNull', () => {
   itConverts(t.noneableAsNull, undefined, null);
   itConverts(t.noneableAsNull, null, null);
   itPassesValueToInnerConverter(t.noneableAsNull);
+  itAttemptsWrappedConvertersBeforeReturning(t.noneableAsNull);
 });
 
 describe('noneableAsUndefined', () => {
   itConverts(t.noneableAsUndefined, undefined, undefined);
   itConverts(t.noneableAsUndefined, null, undefined);
   itPassesValueToInnerConverter(t.noneableAsUndefined);
+  itAttemptsWrappedConvertersBeforeReturning(t.noneableAsUndefined);
 });

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,8 +1,8 @@
-import { ConverterError } from 'type-shift';
+import * as t from 'type-shift';
 
 describe('ConverterError', () => {
   it('exposes error paths', () => {
-    const error = new ConverterError(true, 'number', ['a', 0]);
+    const error = new t.ConverterError(true, 'number', ['a', 0]);
     expect(error.errorFields).toEqual({
       '$.a[0]': {
         expected: 'number',

--- a/src/__tests__/func.test.ts
+++ b/src/__tests__/func.test.ts
@@ -1,15 +1,15 @@
-import { convert } from 'type-shift';
+import * as t from 'type-shift';
 
 describe('convert', () => {
   it('invokes the converter with an empty path and the input', () => {
     const converter = jest.fn((_: unknown) => 1);
-    const c = convert(converter);
+    const c = t.convert(converter);
     (c as any)(5, ['not-empty'], {});
     expect(converter).toHaveBeenLastCalledWith(5, [], 5);
   });
   it('returns the converted result', () => {
     const converter = (_: unknown) => 1;
-    const c = convert(converter);
+    const c = t.convert(converter);
     const r = c(5);
     expect(r).toBe(1);
   });

--- a/src/__tests__/objects.test.ts
+++ b/src/__tests__/objects.test.ts
@@ -117,4 +117,17 @@ describe('partial', () => {
       two: 'test'
     });
   });
+  it('will attempt wrapped converters before returning undefined', () => {
+    const converter = t.partial(
+      t.shape({
+        one: t.string,
+        two: t.forPath([t.ParentPath, 'one'], t.string)
+      })
+    );
+    const v = converter({ one: 'one', two: 'two' });
+    expect(v).toEqual({
+      one: 'one',
+      two: 'one'
+    });
+  });
 });

--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -125,13 +125,13 @@ describe('forPath', () => {
           subChild: t.forPath([t.ParentPath], t.shape({ sibling: t.string }))
         })
       });
-      const testItem = { child: { sibling: 'test' }};
+      const testItem = { child: { sibling: 'test' } };
       expect(testConverter(testItem)).toMatchObject({
         child: {
           subChild: { sibling: 'test' }
         }
       });
-    })
+    });
 
     it("still resolves '.'", () => {
       const testConverter = t.shape({

--- a/src/coercers.ts
+++ b/src/coercers.ts
@@ -1,6 +1,6 @@
 import { displayValue } from './formatting';
 import { Converter } from './core';
-import { None, none } from './basic-types';
+import { none } from './basic-types';
 
 /**
  * Given a set of converters if one succeeds at converting the input return the
@@ -21,9 +21,9 @@ export const coerce = <V>(
 /**
  * A coercer that coerces values of None type to a null literal
  */
-export const noneAsNull: Converter<None> = coerce([none], null);
+export const noneAsNull: Converter<null> = coerce([none], null);
 
 /**
  * A coercer that coerces values of None type to an undefined literal
  */
-export const noneAsUndefined: Converter<None> = coerce([none], undefined);
+export const noneAsUndefined: Converter<undefined> = coerce([none], undefined);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,4 +1,5 @@
-import { None } from './basic-types';
+import { none, None, undefined as undefinedConverter } from './basic-types';
+import { noneAsNull, noneAsUndefined } from './coercers';
 import { Converter, ConverterFunction, createConverter, getConverterName } from './core';
 
 /**
@@ -8,12 +9,13 @@ import { Converter, ConverterFunction, createConverter, getConverterName } from 
  */
 export function optional<Result, Input = unknown>(
   converter: ConverterFunction<Result, Input>
-): Converter<Result | undefined, Input | undefined> {
+): Converter<Result | undefined, Input> {
   return createConverter((input, path, entity) => {
-    if (input === undefined) {
-      return undefined;
+    try {
+      return converter(input, path, entity);
+    } catch {
+      return undefinedConverter(input, path, entity);
     }
-    return converter(input, path, entity);
   }, `optional ${getConverterName(converter)}`);
 }
 
@@ -24,17 +26,13 @@ export function optional<Result, Input = unknown>(
  */
 export function noneable<Result, Input = unknown>(
   converter: ConverterFunction<Result, Input>
-): Converter<Result | None, Input | None> {
+): Converter<Result | None, Input> {
   return createConverter((input, path, entity) => {
-    if (input === undefined) {
-      return undefined;
+    try {
+      return converter(input, path, entity);
+    } catch {
+      return none(input, path, entity);
     }
-
-    if (input === null) {
-      return null;
-    }
-
-    return converter(input, path, entity);
   }, `optional ${getConverterName(converter)}`);
 }
 
@@ -45,12 +43,13 @@ export function noneable<Result, Input = unknown>(
  */
 export function noneableAsNull<Result, Input = unknown>(
   converter: ConverterFunction<Result, Input>
-): Converter<Result | null, Input | None> {
+): Converter<Result | null, Input> {
   return createConverter((input, path, entity) => {
-    if (input === undefined || input === null) {
-      return null;
+    try {
+      return converter(input, path, entity);
+    } catch {
+      return noneAsNull(input, path, entity);
     }
-    return converter(input, path, entity);
   }, `optional ${getConverterName(converter)}`);
 }
 
@@ -61,11 +60,12 @@ export function noneableAsNull<Result, Input = unknown>(
  */
 export function noneableAsUndefined<Result, Input = unknown>(
   converter: ConverterFunction<Result, Input>
-): Converter<Result | undefined, Input | None> {
+): Converter<Result | undefined, Input> {
   return createConverter((input, path, entity) => {
-    if (input === undefined || input === null) {
-      return undefined;
+    try {
+      return converter(input, path, entity);
+    } catch {
+      return noneAsUndefined(input, path, entity);
     }
-    return converter(input, path, entity);
   }, `optional ${getConverterName(converter)}`);
 }


### PR DESCRIPTION
Addresses https://github.com/RateGravity/type-shift/issues/17

First 3 commits are just housekeeping. Last commit is the actual substance.

In the current world, decorators involving Noneables will return immediately if the field matches the None type. This means that complex converters such as path, or, etc, will be ignored. This PR changes the order of operations so the decorated converter will be evaluated first, then the fallback undefined/None/default logic if it fails.

This means we can utilize optional converters with defaults and optional forPaths.
