### PR TITLE
Proposal: Do not allow `shape` or `strict` converters to omit optional fields.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format": "prettier --write 'src/**/*.{ts,js,json}'",
     "lint": "yarn prebuild:lint",
     "test": "yarn prebuild:test",
-    "type-check": "prebuild:typecheck"
+    "type-check": "yarn prebuild:typecheck"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -125,13 +125,13 @@ describe('forPath', () => {
           subChild: t.forPath([t.ParentPath], t.shape({ sibling: t.string }))
         })
       });
-      const testItem = { child: { sibling: 'test' }};
+      const testItem = { child: { sibling: 'test' } };
       expect(testConverter(testItem)).toMatchObject({
         child: {
           subChild: { sibling: 'test' }
         }
       });
-    })
+    });
 
     it("still resolves '.'", () => {
       const testConverter = t.shape({

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -9,7 +9,9 @@ import { ConverterError } from './errors';
  */
 export interface ShapeConverter<S extends object> extends Converter<S, unknown> {
   readonly strict: boolean;
-  readonly converters: { [K in keyof S]: Converter<S[K], unknown> };
+  readonly converters: {
+    [K in keyof Required<S>]: Converter<S[K], unknown>;
+  };
 }
 
 /**
@@ -17,7 +19,7 @@ export interface ShapeConverter<S extends object> extends Converter<S, unknown> 
  * @param converters - an object structure describing the resulting value
  */
 export function strict<S extends object>(
-  converters: { [K in keyof S]: ConverterFunction<S[K], unknown> }
+  converters: { [K in keyof Required<S>]: ConverterFunction<S[K], unknown> }
 ): ShapeConverter<S> {
   const name = `{${(Object.keys(converters) as (keyof S)[])
     .map((key) => `${key}: ${getConverterName(converters[key])}`)
@@ -85,7 +87,7 @@ export function strict<S extends object>(
  * @param converters - an object structure describing the resulting value
  */
 export function shape<S extends object>(
-  converters: { [K in keyof S]: ConverterFunction<S[K], unknown> }
+  converters: { [K in keyof Required<S>]: ConverterFunction<S[K], unknown> }
 ): ShapeConverter<S> {
   const converter = strict(converters);
   return Object.defineProperties(


### PR DESCRIPTION
Forgetting to include fields on your shape converter is a mistake we've all made. With the way type-shift's converter types are set up, "optional" fields also mean the _converter_ is optional. Meaning you won't be warned if you forget to include a converter for an optional field.

While this is a somewhat valid use-case (if the field is optional you can totally ignore it, right?), we've really moved away from that sort of behavior and typically try to ensure our converters are accurate to what is being converted to, so you don't have Typescript telling you a field _might_ exist on an object you told the runtime to exclude (except for the case of `t.shape` which would just treat it as a 1:1 pass-through.) If you wanted to truly ignore a particular field it'd be better to derive a new type with those fields omitted.

Anyway, to summarize the implications of this change, given an interface:

```ts
interface CoolPayload {
  hello: string;
  world: undefined;
  sup?: string;
  nmu?: undefined;
}
```

... you could write the following converter:

```ts
const coolPayloadConverter = t.shape<CoolPayload>({
  hello: t.string,
  world: t.undefined
});
```

Previously, this was accepted by Typescript because it used the optionality of the fields as a basis for what fields were actually required in the converter definition. But with these type changes, Typescript will now throw a type error if you do not include all of the defined fields on the type, even those that are undefined.

```ts
const coolPayloadConverter = t.shape<CoolPayload>({
  hello: t.string,
  world: t.undefined,
  sup: t.optional(t.string),
  nmu: t.undefined
});
```

This _would_ be a breaking change so if we accept it we would increment the major version number.