### PR TITLE
Allow readonly arrays to be used for `t.oneOf`

### DIFF
--- a/src/unions.ts
+++ b/src/unions.ts
@@ -7,7 +7,7 @@ import { displayValue } from './formatting';
  * This uses triple equality (===) to compare
  */
 export function oneOf<V extends string | number | boolean | undefined | null>(
-  options: V[]
+  options: V[] | readonly V[]
 ): Converter<V, unknown> {
   const name = options.map((v) => displayValue(v)).join(' | ');
   return createConverter((value, path) => {


### PR DESCRIPTION
Previously only mutable arrays were allowed to be used in a `t.oneOf` so if you had a declaration like this:

```ts
export const STATES = ['MA','NH','ME'] as const;
export type State = typeof STATES[number];
```

If you wanted to write a `t.oneOf` based on the read-only `STATES` constant you'd have to spread it like so:

```ts
export const statesConverter = t.oneOf<State>([...STATES]);
```

By allowing the type definition to also accept a `readonly` array we can go directly to the source now:

```ts
export const statesConverter = t.oneOf<State>(STATES);
```