### PR TITLE
Enhanced decorator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,20 @@ These converters match their elements against a given converter.
 
 - `strict(<{ [key]: converter function }>)` - Given an object of keys to converters creates a converter that matches input keys with the declared converters and returns the resulting object. Only declared keys are returned.
 - `shape(<{ [key]: converter function }>)` - Same as strict but any keys present on the input that are not declared are also returned.
-- `partial(<strict or shape>)` - Given either a strict or shape converter makes every field optional, maintains strictness.
+
+### Decorators
+
 - `optional(<converter function>)` - Create a converter function that passes undefined input around the inner converter, useful for marking optional fields in objects.
 - `noneable(<converter function>)` - Create a converter function that passes undefined or null input around the inner converter, useful for marking optional fields in objects.
 - `noneableAsNull(<converter function>)` - Create a converter function that coerces undefined or null input to null around the inner converter, useful for marking optional fields in objects.
 - `noneableAsUndefined(<converter function>)` - Create a converter function that coerces undefined or null input to undefined around the inner converter, useful for marking optional fields in objects.
+
+#### Decorated Objects
+
+- `partial(<strict or shape>)` - Given either a strict or shape converter makes every field `optional`, maintains strictness.
+- `noneableChildren(<strict or shape>)` - Given either a strict or shape converter makes every field `noneable`, maintains strictness.
+- `noneableChildrenAsNull(<strict or shape>)` - Given either a strict or shape converter makes every field `noneableAsNull`, maintains strictness.
+- `noneableChildrenAsUndefined(<strict or shape>)` - Given either a strict or shape converter makes every field `noneableAsUndefined`, maintains strictness.
 
 ### Paths
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "prettier": "^2.0.5",
     "rollup": "^2.51.0",
     "rollup-plugin-dts": "^3.0.2",
+    "semver": "^7.6.3",
     "typescript": "^4.2.2"
   },
   "pre-commit": [

--- a/src/__tests__/objects.test.ts
+++ b/src/__tests__/objects.test.ts
@@ -95,26 +95,80 @@ describe('shape', () => {
   });
 });
 
-describe('partial', () => {
-  it('makes all fields optional', () => {
-    const converter = t.partial(
-      t.strict({
-        one: t.string
-      })
-    );
-    const v = converter({});
-    expect(v.one).not.toBeDefined();
+describe('decorate', () => {
+  describe('partial', () => {
+    it('applies the decorator to all fields', () => {
+      const converter = t.decorate(t.optional)(
+        t.shape({
+          one: t.string
+        })
+      );
+      const v = converter({});
+      expect(v.one).not.toBeDefined();
+    });
+
+    it('preserves strictness', () => {
+      const converter = t.decorate(t.optional)(
+        t.shape({
+          one: t.string
+        })
+      );
+      const v = converter({ two: 'test' });
+      expect(v).toEqual({
+        one: undefined,
+        two: 'test'
+      });
+    });
   });
-  it('preserves strictness', () => {
-    const converter = t.partial(
-      t.shape({
-        one: t.string
-      })
-    );
-    const v = converter({ two: 'test' });
-    expect(v).toEqual({
-      one: undefined,
-      two: 'test'
+
+  describe('partial', () => {
+    it('makes all fields optional', () => {
+      const converter = t.partial(
+        t.strict({
+          one: t.string
+        })
+      );
+      const v = converter({});
+      expect(v.one).not.toBeDefined();
+    });
+  });
+
+  describe('noneableChildren', () => {
+    it('makes all fields noneable', () => {
+      const converter = t.noneableChildren(
+        t.shape({
+          one: t.string,
+          two: t.string
+        })
+      );
+      const v = converter({ two: null });
+      expect(v).toEqual({ one: undefined, two: null });
+    });
+  });
+
+  describe('noneableChildrenAsUndefined', () => {
+    it('makes all fields noneableAsUndefined', () => {
+      const converter = t.noneableChildrenAsUndefined(
+        t.shape({
+          one: t.string,
+          two: t.string
+        })
+      );
+      const v = converter({ two: null });
+      expect(v).toEqual({ one: undefined, two: undefined });
+    });
+  });
+
+  describe('noneableChildrenAsNull', () => {
+    it('makes all fields noneableChildrenAsNull', () => {
+      const converter = t.noneableChildrenAsNull(
+        t.shape({
+          one: t.string,
+          two: t.string
+        })
+      );
+      const v = converter({ two: null });
+      expect(v).toEqual({ one: null, two: null });
     });
   });
 });

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -2,6 +2,15 @@ import { None } from './basic-types';
 import { Converter, ConverterFunction, createConverter, getConverterName } from './core';
 
 /**
+ * A decorator is a function that takes a converter function and returns
+ *   a new converter function. The idea is that this new converter function
+ *   will wrap the original converter function and modify its behavior.
+ */
+export type Decorator<Result, Input = unknown> = (
+  converter: ConverterFunction<Result, Input>
+) => ConverterFunction<Result, Input>;
+
+/**
  * Given a converter function make an optional converter function
  * Optional functions allow undefined values to pass-through
  * @param converter - the inner converter function

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -1,5 +1,6 @@
+import { None } from './basic-types';
 import { Converter, ConverterFunction, createConverter, getConverterName } from './core';
-import { optional } from './decorators';
+import { Decorator, noneable, noneableAsNull, noneableAsUndefined, optional } from './decorators';
 import { ConverterError } from './errors';
 
 /**
@@ -7,10 +8,10 @@ import { ConverterError } from './errors';
  * converters that were used to create it. This allows for these
  * converters to be spread, in order to inherit them.
  */
-export interface ShapeConverter<S extends object> extends Converter<S, unknown> {
+export interface ShapeConverter<Result extends object> extends Converter<Result, unknown> {
   readonly strict: boolean;
   readonly converters: {
-    [K in keyof Required<S>]: Converter<S[K], unknown>;
+    [K in keyof Required<Result>]: Converter<Result[K], unknown>;
   };
 }
 
@@ -121,6 +122,40 @@ export function shape<S extends object>(
 }
 
 /**
+ * Given a shape and converter, wraps all members of the shape in that
+ *   converter.
+ *
+ * If the given shape converter was created with the t.strict creator
+ *   the resulting partial will also be strict
+ * @param converter - the shape converter to make partial
+ */
+export function decorate<Result, Input = unknown>(decorator: Decorator<Result, Input>) {
+  return <S extends object>(converter: ShapeConverter<S>): ShapeConverter<S> => {
+    if (converter.strict) {
+      return strict(
+        Object.keys(converter.converters).reduce(
+          (l, key) => ({
+            ...l,
+            [key]: decorator((converter.converters as any)[key])
+          }),
+          {} as any
+        )
+      );
+    } else {
+      return shape(
+        Object.keys(converter.converters).reduce(
+          (l, key) => ({
+            ...l,
+            [key]: decorator((converter.converters as any)[key])
+          }),
+          {} as any
+        )
+      );
+    }
+  };
+}
+
+/**
  * Given a shape converter turns all converters into optionals.
  *
  * If the given shape converter was created with the t.strict creator
@@ -130,25 +165,44 @@ export function shape<S extends object>(
 export function partial<S extends object>(
   converter: ShapeConverter<S>
 ): ShapeConverter<{ [K in keyof S]: S[K] | undefined }> {
-  if (converter.strict) {
-    return strict(
-      Object.keys(converter.converters).reduce(
-        (l, key) => ({
-          ...l,
-          [key]: optional((converter.converters as any)[key])
-        }),
-        {} as any
-      )
-    );
-  } else {
-    return shape(
-      Object.keys(converter.converters).reduce(
-        (l, key) => ({
-          ...l,
-          [key]: optional((converter.converters as any)[key])
-        }),
-        {} as any
-      )
-    );
-  }
+  return decorate(optional)(converter);
+}
+
+/**
+ * Given a shape converter turns all converters into noneable.
+ *
+ * If the given shape converter was created with the t.strict creator
+ * the resulting partial will also be strict
+ * @param converter - the shape converter to wrap all fields in noneable
+ */
+export function noneableChildren<S extends object>(
+  converter: ShapeConverter<S>
+): ShapeConverter<{ [K in keyof S]: S[K] | None }> {
+  return decorate(noneable)(converter);
+}
+
+/**
+ * Given a shape converter turns all converters into noneableAsUndefined.
+ *
+ * If the given shape converter was created with the t.strict creator
+ * the resulting partial will also be strict
+ * @param converter - the shape converter to wrap all fields in noneableAsUndefined
+ */
+export function noneableChildrenAsUndefined<S extends object>(
+  converter: ShapeConverter<S>
+): ShapeConverter<{ [K in keyof S]: S[K] | undefined }> {
+  return decorate(noneableAsUndefined)(converter);
+}
+
+/**
+ * Given a shape converter turns all converters into noneableAsNull.
+ *
+ * If the given shape converter was created with the t.strict creator
+ * the resulting partial will also be strict
+ * @param converter - the shape converter to wrap all fields in noneableAsNull
+ */
+export function noneableChildrenAsNull<S extends object>(
+  converter: ShapeConverter<S>
+): ShapeConverter<{ [K in keyof S]: S[K] | null }> {
+  return decorate(noneableAsNull)(converter);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,6 +4895,11 @@ semver@^7.2.1, semver@^7.3.2:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
Make "decorators" a more well-defined concept. Add a `decorate` helper function and use that to define the existing `partial` helper (decorator that uses `optional`.) Create "decorated" versions of `noneable`, `noneableAsUndefined`, and `noneableAsNull`.