### PR TITLE
Standard schema support

### DIFF
--- a/src/__tests__/core.test.ts
+++ b/src/__tests__/core.test.ts
@@ -83,7 +83,7 @@ describe('createConverter', () => {
   it('or throws error with more errors', () => {
     const less = new ConverterError('test', 'not-test', ['field', 0]);
     const more = new ConverterError('test', 'not-test', ['field', 0]);
-    more.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
+    more.issues.push({ path: ['field', 1], expected: 'test', actual: 'not-test' });
     const converter = createConverter(() => {
       throw less;
     }).or(() => {
@@ -103,7 +103,7 @@ describe('createConverter', () => {
   });
   it('or prefers deeper errors over more errors', () => {
     const moreShallow = new ConverterError('test', 'not-test', ['field', 0]);
-    moreShallow.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
+    moreShallow.issues.push({ path: ['field', 1], expected: 'test', actual: 'not-test' });
     const lessDeep = new ConverterError('test', 'not-test', ['field', 0, 'other']);
     const converter = createConverter(() => {
       throw moreShallow;
@@ -114,11 +114,11 @@ describe('createConverter', () => {
   });
   it('or uses count of errors at max depth', () => {
     const twoDeepest = new ConverterError('test', 'not-test', ['field']);
-    twoDeepest.errorFields['$.field[0]'] = { expected: 'test', actual: 'not-test' };
-    twoDeepest.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
+    twoDeepest.issues.push({ path: ['field', 0], expected: 'test', actual: 'not-test' });
+    twoDeepest.issues.push({ path: ['field', 1], expected: 'test', actual: 'not-test' });
     const oneDeepest = new ConverterError('test', 'not-test', ['field']);
-    oneDeepest.errorFields['$.other'] = { expected: 'test', actual: 'not-test' };
-    oneDeepest.errorFields['$.field[0]'] = { expected: 'test', actual: 'not-test' };
+    oneDeepest.issues.push({ path: ['other'], expected: 'test', actual: 'not-test' });
+    oneDeepest.issues.push({ path: ['field', 0], expected: 'test', actual: 'not-test' });
     const converter = createConverter(() => {
       throw twoDeepest;
     }).or(() => {
@@ -128,11 +128,11 @@ describe('createConverter', () => {
   });
   it('or throws new errors if the errors tie depth and count', () => {
     const errorOne = new ConverterError('test', 'not-test', ['field']);
-    errorOne.errorFields['$.field[0]'] = { expected: 'test', actual: 'not-test' };
-    errorOne.errorFields['$.field[1]'] = { expected: 'test', actual: 'not-test' };
+    errorOne.issues.push({ path: ['field', 0], expected: 'test', actual: 'not-test' });
+    errorOne.issues.push({ path: ['field', 1], expected: 'test', actual: 'not-test' });
     const errorTwo = new ConverterError('test', 'not-test', ['other']);
-    errorTwo.errorFields['$.other[0]'] = { expected: 'test', actual: 'not-test' };
-    errorTwo.errorFields['$.other[1]'] = { expected: 'test', actual: 'not-test' };
+    errorTwo.issues.push({ path: ['other', 0], expected: 'test', actual: 'not-test' });
+    errorTwo.issues.push({ path: ['other', 1], expected: 'test', actual: 'not-test' });
     const converter = createConverter(() => {
       throw errorOne;
     }).or(() => {

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -10,4 +10,15 @@ describe('ConverterError', () => {
       }
     });
   });
+
+  it('exposes issues', () => {
+    const error = new ConverterError(true, 'number', ['a', 0]);
+    expect(error.issues).toEqual([
+      {
+        path: ['a', 0],
+        expected: 'number',
+        actual: true
+      }
+    ]);
+  });
 });

--- a/src/container.ts
+++ b/src/container.ts
@@ -40,7 +40,7 @@ export function record<T>(
       .reduce((acc, obj) => ({ ...acc, ...obj }), {}) as Record<string, T>;
     if (errors.length > 0) {
       throw errors.reduce((l, r) => {
-        Object.assign(l.errorFields, r.errorFields);
+        l.issues.push(...r.issues);
         return l;
       });
     }
@@ -74,7 +74,7 @@ export function array<T>(converter: ConverterFunction<T, unknown>): Converter<T[
     });
     if (errors.length > 0) {
       throw errors.reduce((l, r) => {
-        Object.assign(l.errorFields, r.errorFields);
+        l.issues.push(...r.issues);
         return l;
       });
     }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,17 +1,9 @@
 import { ConverterError } from './errors';
 
-// count the number of dots or open brackets
-// this avoids complex path parsing while getting a "good enough" hueristic
-function guessPathLength(formattedPath: string): number {
-  return Array.from(formattedPath)
-    .map((v) => (v === '.' || v === '[' ? 1 : 0))
-    .reduce((l: number, r: number): number => l + r, 0);
-}
-
 // find the count of errors at the max depth.
 function maxDepthCount(error: ConverterError): { depth: number; count: number } {
-  return Object.keys(error.errorFields)
-    .map(guessPathLength)
+  return error.issues
+    .map(({ path }) => path.length)
     .reduce(
       (max: { depth: number; count: number }, d) => {
         if (d === max.depth) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,6 @@
+import { StandardSchemaV1 } from './standard-schema';
 import { ConverterError } from './errors';
+import { displayValue } from './formatting';
 
 // find the count of errors at the max depth.
 function maxDepthCount(error: ConverterError): { depth: number; count: number } {
@@ -19,6 +21,45 @@ function maxDepthCount(error: ConverterError): { depth: number; count: number } 
 }
 
 /**
+ * Convert a converter function into a StandardSchema validator function
+ * @param converter - the converter function to convert
+ * @returns a validator function
+ */
+function asValidator<Input, Result>(
+  converter: ConverterFunction<Result, Input>
+): StandardSchemaV1.Props<Input, Result>['validate'] {
+  return (input: unknown) => {
+    try {
+      return {
+        // standard schema specifies an input type but then the function uses unknown
+        value: converter(input as Input, [], input)
+      };
+    } catch (error) {
+      if (error instanceof ConverterError) {
+        // convert ConverterError into the StandardSchemaV1.FailureResult
+        return {
+          issues: error.issues.map(({ path, expected, actual }) => ({
+            message: `expected ${expected} but was ${displayValue(actual)}`,
+            path: path
+          }))
+        };
+      }
+      // convert other errors into the FailureResult
+      return {
+        issues: [
+          {
+            message:
+              error !== null && typeof error === 'object' && 'message' in error
+                ? `${error.message}`
+                : `${error}`
+          }
+        ]
+      };
+    }
+  };
+}
+
+/**
  * A Converter Function
  */
 export interface ConverterFunction<Result, Input = unknown> {
@@ -34,7 +75,9 @@ export interface ConverterFunction<Result, Input = unknown> {
 /**
  * A standard Converter function with extended methods
  */
-export interface Converter<Result, Input = unknown> extends ConverterFunction<Result, Input> {
+export interface Converter<Result, Input = unknown>
+  extends ConverterFunction<Result, Input>,
+    StandardSchemaV1<Input, Result> {
   /**
    * The Name of the converter
    */
@@ -170,6 +213,15 @@ export function createConverter<Result, Input = unknown>(
             }
             return converter(input as Input, path, entity);
           }, defaultedName);
+        },
+        writable: false,
+        enumerable: true
+      },
+      '~standard': {
+        value: {
+          version: 1,
+          vendor: 'type-shift',
+          validate: asValidator(converter)
         },
         writable: false,
         enumerable: true

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,19 +6,36 @@ import { displayValue, formatPath } from './formatting';
  */
 export class ConverterError extends Error {
   /**
+   * The issues that occured during the conversion
+   */
+  public readonly issues: {
+    path: (string | number)[];
+    actual: unknown;
+    expected: string;
+  }[];
+
+  /**
    * Error Fields records the path to fields that have an error.
    * The key of the errorFields is a path in the form of $.part[index]
    */
-  public readonly errorFields: Record<string, { expected: string; actual: unknown }>;
+  public get errorFields(): Record<string, { expected: string; actual: unknown }> {
+    return Object.fromEntries(
+      this.issues.map(({ path, actual, expected }) => [
+        formatPath(path),
+        { expected, actual: displayValue(actual) }
+      ])
+    );
+  }
 
   constructor(actual: unknown, expected: string, path: (string | number)[]) {
     super(`At Path ${formatPath(path)}, expected ${expected} but was ${displayValue(actual)}`);
     this.name = 'ConverterError';
-    this.errorFields = {
-      [formatPath(path)]: {
-        expected,
-        actual: displayValue(actual)
+    this.issues = [
+      {
+        path,
+        actual,
+        expected
       }
-    };
+    ];
   }
 }

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -53,7 +53,7 @@ export function strict<S extends object>(
         .reduce((acc, obj) => ({ ...acc, ...obj }), {}) as S;
       if (errors.length > 0) {
         throw errors.reduce((l, r) => {
-          Object.assign(l.errorFields, r.errorFields);
+          l.issues.push(...r.issues);
           return l;
         });
       }

--- a/src/standard-schema.ts
+++ b/src/standard-schema.ts
@@ -1,0 +1,74 @@
+/* eslint-disable */
+/* from: https://raw.githubusercontent.com/standard-schema/standard-schema/refs/heads/main/packages/spec/src/index.ts
+
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+    /** The Standard Schema properties. */
+    readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+  }
+
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1;
+    /** The vendor name of the schema library. */
+    readonly vendor: string;
+    /** Validates unknown input values. */
+    readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>;
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output;
+    /** The non-existent issues. */
+    readonly issues?: undefined;
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string;
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+  }
+
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey;
+  }
+
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input;
+    /** The output type of the schema. */
+    readonly output: Output;
+  }
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['input'];
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['output'];
+
+  // biome-ignore lint/complexity/noUselessEmptyExport: needed for granular visibility control of TS namespace
+  export {};
+}


### PR DESCRIPTION
Standard Schema - https://standardschema.dev/

Standard Schema is a common interface for typescript validation libraries that allows tools like tRPC, or Tanstack Form to target a single schema and different validation libraries to do the same. It prevents validation library vendor lock-in and allows for newer validation libraries to quickly gain market share by just working with the different consumers of standard schema.

This PR updates the type definition of Converter to include the implementation of StandardSchema by wrapping the converter function and handling validation. In order to make this support easier it also adds a new issues field to converter errors so that they can be easily translated into standard schema failure results. This also simplifies a lot of the operations that have previously been done with the error paths.