### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-package.yaml
+++ b/.github/workflows/deploy-package.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   DeployPackage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checking out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/RateGravity/type-shift/security/code-scanning/1](https://github.com/RateGravity/type-shift/security/code-scanning/1)

To fix the problem, add a `permissions` block to the relevant section of the workflow. The decision is whether to add it at the root level (so it applies to all jobs), or directly inside the `DeployPackage` job. In this snippet, there is only one job (`DeployPackage`), so placing it at the job level or the workflow level will have the same effect. The least privilege needed for this job is typically `contents: read`, but if the `yarn deploy` step is publishing packages or making changes to the repository, additional permissions may be needed (e.g. `packages: write` or `contents: write`). For a minimal fix per CodeQL's suggestion, set `contents: read`. This should be added just below the `runs-on: ubuntu-latest` line (line 9) or above that at the job level. No additional imports, variable definitions, or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
